### PR TITLE
[Gardening] Replace usage of ! for self access

### DIFF
--- a/Sources/PetFocus/PetDetectionOperation.swift
+++ b/Sources/PetFocus/PetDetectionOperation.swift
@@ -14,20 +14,20 @@ class PetDetectionOperation: Operation {
     }
 
     override func start() {
-        let imageRequest = VNDetectAnimalRectanglesRequest { [weak self] request, error in
+        let imageRequest = VNDetectAnimalRectanglesRequest { [unowned self] request, error in
             guard let results = request.results else {
-                self?.completionHandler(nil, error)
-                self?._finished = true
-                self?._executing = false
+                self.completionHandler(nil, error)
+                self._finished = true
+                self._executing = false
                 return
             }
 
             let recognizedObjectObservations = results.compactMap { $0 as? VNRecognizedObjectObservation }
-            let petObservations = recognizedObjectObservations.compactMap { PetObservation($0, in: self!.image)}
-            self?.completionHandler(petObservations, nil)
+            let petObservations = recognizedObjectObservations.compactMap { PetObservation($0, in: self.image)}
+            self.completionHandler(petObservations, nil)
 
-            self?._finished = true
-            self?._executing = false
+            self._finished = true
+            self._executing = false
         }
 
         do {


### PR DESCRIPTION
Hey there! Love the repo and its functionality. After reading through the code I wanted to suggest a small modification to the `PetDetectionOperation` syntax.

### What does this PR do?
Replaces the single use of the `!` unwrap to access the `image` object. Since this has the same behavior as an `unowned` capture from a safety standpoint, I replaced the capture syntax. Behavior should be the same as before, but less `?` and `!` in the code. Lemme know what you think!